### PR TITLE
chore: remove unused default value in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,6 @@ name: netlify-plugin-webmentions
 inputs:
   - name: baseUrl
     description: The base url of your site
-    default: 
   - name: feedPath
     description: "Path to your site's feed, without a leading slash (Default: feed.xml)"
   - name: limit


### PR DESCRIPTION
Seems like this `default` value for the `baseUrl` isn't currently being used. Let us know if that isn't the case though 👍 