### PR TITLE
Improve error handling to prevent build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Netlify Build Plugin: Automatically discover any webmentions and send them after every production build
 
+> **Note:** This is a fork of [CodeFoodPixels/netlify-plugin-webmentions](https://github.com/CodeFoodPixels/netlify-plugin-webmentions) with improved error handling that logs warnings instead of failing the build on timeouts/errors.
+>
+> To use this fork instead of the npm package (which also overrides the Netlify app plugin):
+> ```bash
+> npm install -D github:miklb/netlify-plugin-webmentions
+> ```
+> Then add to `netlify.toml`:
+> ```toml
+> [[plugins]]
+> package = "netlify-plugin-webmentions"
+> ```
+
 Automatically discover any webmentions and send them after every production build.
 
 This plugin will send webmentions to any mentioned websites that have a webmention endpoint after every production build. The plugin can be used without any configuration if using the defaults.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/CodeFoodPixels/netlify-plugin-webmentions#readme",
   "dependencies": {
-    "@remy/webmention": "^1.4.5"
+    "@remy/webmention": "^1.5.0"
   },
   "devDependencies": {
     "prettier": "^2.2.1"


### PR DESCRIPTION
Changes error handling from rejecting promises to logging warnings, allowing the build to complete even when webmention discovery encounters timeouts or other transient errors.

Previously, any error in webmention discovery would fail the entire Netlify build via utils.build.failPlugin(). This change catches errors, logs them as warnings, and tracks the error count while still completing the build successfully.

Also updates @remy/webmention dependency from ^1.4.5 to ^1.5.0.

Fixes #5 